### PR TITLE
ATLAB-8094 workaround cs47 docker old version

### DIFF
--- a/tools/scripts/build-alluxio.sh
+++ b/tools/scripts/build-alluxio.sh
@@ -107,10 +107,10 @@ fi
 cd $DIR/../..
 if [ $build_image != "false" ]; then
   echo "building docker image"
-  cp $DIR/docker-image/entrypoint.sh .tmp/alluxio/
+  cp $DIR/docker-image/Dockerfile.alluxio $DIR/docker-image/entrypoint.sh .tmp/alluxio/
   cd $local_alluxio && alluxio_hash=`git rev-parse --short=7 HEAD` && cd -
   cd $local_kodo && kodo_hash=`git rev-parse --short=7 HEAD` && cd -
-  docker build -t alluxio:$alluxio_hash-$kodo_hash --build-arg ALLUXIO_VERSION="${alluxio_version}" -f $DIR/docker-image/Dockerfile.alluxio .tmp/alluxio
+  docker build -t alluxio:$alluxio_hash-$kodo_hash --build-arg ALLUXIO_VERSION="${alluxio_version}" -f .tmp/alluxio/Dockerfile.alluxio .tmp/alluxio
   if [ $push_image != "false" ]; then
     docker tag alluxio:$alluxio_hash-$kodo_hash reg-xs.qiniu.io/atlab/alluxio:$alluxio_hash-$kodo_hash
     docker push reg-xs.qiniu.io/atlab/alluxio:$alluxio_hash-$kodo_hash


### PR DESCRIPTION
### issues

* [ATLAB-8094](https://jira.qiniu.io/browse/ATLAB-8094)


### TODOs
- [x] [修复] 修复 jenkins 机器 cs47 上面老版本的 docker 无法支持 Dockerfile 不在 context 里的问题

### checklist
- [ ] linted
- [ ] tested
- [ ] reviewed

