### PR TITLE
change workers and SSD of some groups

### DIFF
--- a/deploy/docker/cube/blademaster/worker.sh
+++ b/deploy/docker/cube/blademaster/worker.sh
@@ -2,12 +2,12 @@
 
 ######################################################################
 # worker node list:
-# jq65 jq66
+# jq65 jq66 jq67
 ######################################################################
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 export GROUP=blademaster
-export NODE_LIST="jq65 jq66"
+export NODE_LIST="jq65 jq66 jq67"
 
 ${DIR}/../template/worker.sh "$@"

--- a/deploy/docker/cube/blademaster/worker.sh
+++ b/deploy/docker/cube/blademaster/worker.sh
@@ -2,12 +2,12 @@
 
 ######################################################################
 # worker node list:
-# jq65 jq66 jq67 jq68 jq69
+# jq65 jq66
 ######################################################################
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 export GROUP=blademaster
-export NODE_LIST="jq65 jq66 jq67 jq68 jq69"
+export NODE_LIST="jq65 jq66"
 
 ${DIR}/../template/worker.sh "$@"

--- a/deploy/docker/cube/blademaster/worker.write.sh
+++ b/deploy/docker/cube/blademaster/worker.write.sh
@@ -2,12 +2,12 @@
 
 ######################################################################
 # worker node list:
-# jq66
+# jq66 jq67
 ######################################################################
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 export GROUP=blademaster
-export NODE_LIST="jq66"
+export NODE_LIST="jq66 jq67"
 
 ${DIR}/../template/worker.write.sh "$@"

--- a/deploy/docker/cube/blademaster/worker.write.sh
+++ b/deploy/docker/cube/blademaster/worker.write.sh
@@ -2,12 +2,12 @@
 
 ######################################################################
 # worker node list:
-# jq66 jq67
+# jq66
 ######################################################################
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 export GROUP=blademaster
-export NODE_LIST="jq66 jq67"
+export NODE_LIST="jq66"
 
 ${DIR}/../template/worker.write.sh "$@"

--- a/deploy/docker/cube/face/worker.sh
+++ b/deploy/docker/cube/face/worker.sh
@@ -2,12 +2,12 @@
 
 ######################################################################
 # worker node list:
-# jq20 jq21 jq40 jq41 jq42
+# jq20 jq21 jq40 jq41 jq42 jq56
 ######################################################################
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 export GROUP=face
-export NODE_LIST="jq20 jq21 jq40 jq41 jq42"
+export NODE_LIST="jq20 jq21 jq40 jq41 jq42 jq56"
 
 ${DIR}/../template/worker.sh "$@"

--- a/deploy/docker/cube/general-reg/worker.sh
+++ b/deploy/docker/cube/general-reg/worker.sh
@@ -2,12 +2,12 @@
 
 ######################################################################
 # worker node list:
-# jq65 jq66 jq67 jq68 jq69
+# jq65 jq66 jq67 jq68 jq69 jq70 jq71 jq73
 ######################################################################
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 export GROUP=general-reg
-export NODE_LIST="jq65 jq66 jq67 jq68 jq69"
+export NODE_LIST="jq65 jq66 jq67 jq68 jq69 jq70 jq71 jq73"
 
 ${DIR}/../template/worker.sh "$@"

--- a/deploy/docker/cube/general-reg/worker.sh
+++ b/deploy/docker/cube/general-reg/worker.sh
@@ -2,12 +2,12 @@
 
 ######################################################################
 # worker node list:
-# jq65 jq66 jq67 jq68 jq69 jq70 jq71 jq73
+# jq65 jq66 jq67 jq68 jq69 jq70 jq71 jq73 jq19 jq21
 ######################################################################
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 export GROUP=general-reg
-export NODE_LIST="jq65 jq66 jq67 jq68 jq69 jq70 jq71 jq73"
+export NODE_LIST="jq65 jq66 jq67 jq68 jq69 jq70 jq71 jq73 jq19 jq21"
 
 ${DIR}/../template/worker.sh "$@"

--- a/deploy/docker/cube/general-reg/worker.write.sh
+++ b/deploy/docker/cube/general-reg/worker.write.sh
@@ -2,12 +2,12 @@
 
 ######################################################################
 # worker node list:
-# jq67 jq68
+# jq67 jq68 jq70 jq71 jq73
 ######################################################################
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 export GROUP=general-reg
-export NODE_LIST="jq67 jq68"
+export NODE_LIST="jq67 jq68 jq70 jq71 jq73"
 
 ${DIR}/../template/worker.write.sh "$@"

--- a/deploy/docker/cube/general-reg/worker.write.sh
+++ b/deploy/docker/cube/general-reg/worker.write.sh
@@ -2,12 +2,12 @@
 
 ######################################################################
 # worker node list:
-# jq67 jq68 jq70 jq71 jq73
+# jq67 jq68 jq40 jq41 jq57 jq54
 ######################################################################
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 export GROUP=general-reg
-export NODE_LIST="jq67 jq68 jq70 jq71 jq73"
+export NODE_LIST="jq67 jq68 jq40 jq41 jq57 jq54"
 
 ${DIR}/../template/worker.write.sh "$@"

--- a/deploy/docker/cube/ocr/worker.sh
+++ b/deploy/docker/cube/ocr/worker.sh
@@ -2,12 +2,12 @@
 
 ######################################################################
 # worker node list:
-# jq68 jq69
+# jq68 jq69 jq40 jq41
 ######################################################################
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 export GROUP=ocr
-export NODE_LIST="jq68 jq69"
+export NODE_LIST="jq68 jq69 jq40 jq41"
 
 ${DIR}/../template/worker.sh "$@"

--- a/deploy/docker/cube/terror/worker.sh
+++ b/deploy/docker/cube/terror/worker.sh
@@ -2,12 +2,12 @@
 
 ######################################################################
 # worker node list:
-# jq65 jq66 jq67
+# jq65 jq66
 ######################################################################
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 export GROUP=terror
-export NODE_LIST="jq65 jq66 jq67"
+export NODE_LIST="jq65 jq66"
 
 ${DIR}/../template/worker.sh "$@"

--- a/deploy/docker/cube/terror/worker.write.sh
+++ b/deploy/docker/cube/terror/worker.write.sh
@@ -2,12 +2,12 @@
 
 ######################################################################
 # worker node list:
-# jq65 jq66
+# jq65
 ######################################################################
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 export GROUP=terror
-export NODE_LIST="jq65 jq66"
+export NODE_LIST="jq65"
 
 ${DIR}/../template/worker.write.sh "$@"

--- a/deploy/docker/cube/video/worker.sh
+++ b/deploy/docker/cube/video/worker.sh
@@ -2,12 +2,12 @@
 
 ######################################################################
 # worker node list:
-# jq40 jq41 jq42 jq56 jq57
+# jq40 jq41 jq42 jq56 jq57 jq67 jq68 jq69
 ######################################################################
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 export GROUP=video
-export NODE_LIST="jq40 jq41 jq42 jq56 jq57"
+export NODE_LIST="jq40 jq41 jq42 jq56 jq57 jq67 jq68 jq69"
 
 ${DIR}/../template/worker.sh "$@"

--- a/deploy/docker/cube/video/worker.sh
+++ b/deploy/docker/cube/video/worker.sh
@@ -2,12 +2,12 @@
 
 ######################################################################
 # worker node list:
-# jq40 jq41 jq42 jq56 jq57 jq67 jq68 jq69
+# jq40 jq41 jq42 jq56 jq57 jq68 jq69 jq42 jq15 jq20
 ######################################################################
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 export GROUP=video
-export NODE_LIST="jq40 jq41 jq42 jq56 jq57 jq67 jq68 jq69"
+export NODE_LIST="jq40 jq41 jq42 jq56 jq57 jq68 jq69 jq42 jq15 jq20"
 
 ${DIR}/../template/worker.sh "$@"

--- a/deploy/docker/cube/video/worker.write.sh
+++ b/deploy/docker/cube/video/worker.write.sh
@@ -2,12 +2,12 @@
 
 ######################################################################
 # worker node list:
-# jq42
+# jq42 jq66 jq67
 ######################################################################
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 export GROUP=video
-export NODE_LIST="jq42"
+export NODE_LIST="jq42 jq66 jq67"
 
 ${DIR}/../template/worker.write.sh "$@"

--- a/deploy/docker/cube/video/worker.write.sh
+++ b/deploy/docker/cube/video/worker.write.sh
@@ -2,12 +2,12 @@
 
 ######################################################################
 # worker node list:
-# jq42 jq66 jq67
+# jq42 jq65 jq69
 ######################################################################
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 export GROUP=video
-export NODE_LIST="jq42 jq66 jq67"
+export NODE_LIST="jq42 jq65 jq69"
 
 ${DIR}/../template/worker.write.sh "$@"


### PR DESCRIPTION
### issues
https://jira.qiniu.io/browse/ATLAB-10080
添加 SSD 资源后，重启部分 worker，并根据各集群用量实情调整各组worker数量
### 修改
1. 增加video组和general-reg组的worker数。
2. 减少blademaster组，terror组的worker数。
3. 其它组不变。
---------------
### 第二次commit修改
1. 调整第一次commit的worker分配情况
2. 使得每个机器上最好能有三个读worker（没有master的情况下）。master占内存不高时，最好有一个读/写worker。增大资源利用率。