### PR TITLE
change the default block size of group video

### DIFF
--- a/deploy/env/client/alluxio-site-video.properties
+++ b/deploy/env/client/alluxio-site-video.properties
@@ -7,3 +7,4 @@ alluxio.user.file.write.tier.default=1
 alluxio.user.network.netty.channel.pool.size.max=256
 alluxio.user.file.writetype.default=ASYNC_THROUGH
 alluxio.user.short.circuit.enabled=false
+alluxio.user.block.size.bytes.default=20GB

--- a/deploy/kubenetes/alluxio/dashboard.yml
+++ b/deploy/kubenetes/alluxio/dashboard.yml
@@ -216,7 +216,7 @@ spec:
         - name: atlab-images
       containers:
       - name: nginx
-        image: reg-xs.qiniu.io/atlab/alluxio-nginx:ava-alluxio-0.1.29
+        image: reg-xs.qiniu.io/atlab/alluxio-nginx:ava-alluxio-0.1.31
         ports:
         - containerPort: 8080
         resources:


### PR DESCRIPTION
### issues
增大video组的default block size，从512MB增大到20GB
